### PR TITLE
Expected missing

### DIFF
--- a/r_markdown/co2.Rmd
+++ b/r_markdown/co2.Rmd
@@ -243,3 +243,8 @@ Addtional bad tests
 
 $CO_{2}$ was measured during `r length(unique(co2_merged$id))` experiments between `r min(co2_merged$date, na.rm = TRUE)` and `r max(co2_merged$date, na.rm = TRUE)`. There is no $CO_{2}$ data for tests: `r setdiff(as.character(samples$id), as.character(co2_merged$id))`.
 
+$CO2$ data is expected to be missing for: 
+
+All "G" tests: dilution system was not run during backgrounds.
+
+17C: test date 4/1/2016. Appears, based on timing of tests and the dilution file for the study day, that we just were not logging dilution C02 data on this day even though the system was runnng. Can probably apply the dilution ratio from other tests of the day to this test.  

--- a/r_markdown/co2.Rmd
+++ b/r_markdown/co2.Rmd
@@ -247,4 +247,4 @@ $CO2$ data is expected to be missing for:
 
 All "G" tests: dilution system was not run during backgrounds.
 
-17C: test date 4/1/2016. Appears, based on timing of tests and the dilution file for the study day, that we just were not logging dilution C02 data on this day even though the system was runnng. Can probably apply the dilution ratio from other tests of the day to this test.  
+17C: test date 4/1/2016. Appears, based on timing of tests and the dilution file for the study day, that we just were not logging dilution C02 data on this day even though the system was runnng. Can probably apply the dilution ratio from other tests of the day to this test.

--- a/r_markdown/fivegas.Rmd
+++ b/r_markdown/fivegas.Rmd
@@ -331,4 +331,4 @@ All "G" tests: five gas not run during backgrounds.
 
 1B, 2A: "no data" noted on QC log
 
-4A: only calibration file for this test day was found (2/24/2016); five gas file is lost. 
+4A: only calibration file for this test day was found (2/24/2016); five gas file is lost.

--- a/r_markdown/fivegas.Rmd
+++ b/r_markdown/fivegas.Rmd
@@ -323,3 +323,12 @@ Addtional bad tests
 ## Summary
 
 The $Fivegas$ measured during `r length(unique(fivegas_merged$id))` experiments between `r min(fivegas_merged$date, na.rm = TRUE)` and `r max(fivegas_merged$date, na.rm = TRUE)`. There is no $Fivegas$ data for tests: `r setdiff(as.character(samples$id), as.character(fivegas_merged$id))`.
+
+
+$Fivegas$ data is expected to be missing for: 
+
+All "G" tests: five gas not run during backgrounds.
+
+1B, 2A: "no data" noted on QC log
+
+4A: only calibration file for this test day was found (2/24/2016); five gas file is lost. 

--- a/r_markdown/fivegas.Rmd
+++ b/r_markdown/fivegas.Rmd
@@ -324,7 +324,6 @@ Addtional bad tests
 
 The $Fivegas$ measured during `r length(unique(fivegas_merged$id))` experiments between `r min(fivegas_merged$date, na.rm = TRUE)` and `r max(fivegas_merged$date, na.rm = TRUE)`. There is no $Fivegas$ data for tests: `r setdiff(as.character(samples$id), as.character(fivegas_merged$id))`.
 
-
 $Fivegas$ data is expected to be missing for: 
 
 All "G" tests: five gas not run during backgrounds.

--- a/r_markdown/grav.Rmd
+++ b/r_markdown/grav.Rmd
@@ -243,5 +243,4 @@ The limit of detection is calculated to be `r round(sd(grav_merged$wgt_blank_del
 
 $Gravimetric$ data was collected during `r length(unique(grav_merged$id))` experiments between `r min(grav_merged$date, na.rm = TRUE)` and `r max(grav_merged$date, na.rm = TRUE)`. There is no $Gravimetric$ data for tests: `r setdiff(as.character(samples$id), as.character(grav_merged$id))`.
 
-
 $PAX$ data is expected to be missing for: 17A only. Filter ruptured so could not be post-weighed. 

--- a/r_markdown/grav.Rmd
+++ b/r_markdown/grav.Rmd
@@ -245,4 +245,3 @@ $Gravimetric$ data was collected during `r length(unique(grav_merged$id))` exper
 
 
 $PAX$ data is expected to be missing for: 17A only. Filter ruptured so could not be post-weighed. 
-

--- a/r_markdown/grav.Rmd
+++ b/r_markdown/grav.Rmd
@@ -242,3 +242,7 @@ The limit of detection is calculated to be `r round(sd(grav_merged$wgt_blank_del
 ## Summary
 
 $Gravimetric$ data was collected during `r length(unique(grav_merged$id))` experiments between `r min(grav_merged$date, na.rm = TRUE)` and `r max(grav_merged$date, na.rm = TRUE)`. There is no $Gravimetric$ data for tests: `r setdiff(as.character(samples$id), as.character(grav_merged$id))`.
+
+
+$PAX$ data is expected to be missing for: 17A only. Filter ruptured so could not be post-weighed. 
+

--- a/r_markdown/pax.Rmd
+++ b/r_markdown/pax.Rmd
@@ -180,3 +180,11 @@ Addtional bad tests
 ## Data summary
 
 The $PAX$ measured during `r length(unique(pax_merged$id))` experiments between `r min(pax_merged$date, na.rm = TRUE)` and `r max(pax_merged$date, na.rm = TRUE)`. There is no $PAX$ data for tests: `r setdiff(as.character(samples$id), as.character(pax_merged$id))`.
+
+
+$PAX$ data is expected to be missing for: 
+
+All "G" background tests. PAX was not run during backgrounds. 
+
+26A: PAX stopped at 3pm this day, and this test was in late afternoon (after 3pm)
+29A, 2A: there is a file for these days, but looks like there is an issue with the wood log times that is causing them not to line up? 

--- a/r_markdown/pax.Rmd
+++ b/r_markdown/pax.Rmd
@@ -158,7 +158,7 @@ Addtional bad tests
   ggplot(p_data) +
          geom_line(mapping = aes(datetime, babs_1_mm), colour = "black") +
          geom_line(mapping = aes(datetime, bscat_1_mm), colour = "royalblue2") +
-         facet_wrap(~id, ncol = 2, scales = "free") + 
+         facet_wrap(~id, ncol = 2, scales = "free") +
          theme_minimal() +
          labs(x = "", y = expression(Mm^{-1}))
 ```
@@ -172,7 +172,7 @@ Addtional bad tests
   ggplot(p_data) +
          geom_line(mapping = aes(datetime, babs_1_mm, colour = qc)) +
          geom_line(mapping = aes(datetime, bscat_1_mm, colour = qc)) +
-        facet_wrap(~id, ncol = 2, scales = "free") + 
+        facet_wrap(~id, ncol = 2, scales = "free") +
         theme_minimal() +
         labs(x = "", y = expression(Mm^{-1}))
 ```
@@ -182,9 +182,9 @@ Addtional bad tests
 The $PAX$ measured during `r length(unique(pax_merged$id))` experiments between `r min(pax_merged$date, na.rm = TRUE)` and `r max(pax_merged$date, na.rm = TRUE)`. There is no $PAX$ data for tests: `r setdiff(as.character(samples$id), as.character(pax_merged$id))`.
 
 
-$PAX$ data is expected to be missing for: 
+$PAX$ data is expected to be missing for:
 
-All "G" background tests. PAX was not run during backgrounds. 
+All "G" background tests. PAX was not run during backgrounds.
 
 26A: PAX stopped at 3pm this day, and this test was in late afternoon (after 3pm)
-29A, 2A: there is a file for these days, but looks like there is an issue with the wood log times that is causing them not to line up? 
+29A, 2A: there is a file for these days, but looks like there is an issue with the wood log times that is causing them not to line up?

--- a/r_markdown/scale.Rmd
+++ b/r_markdown/scale.Rmd
@@ -89,4 +89,3 @@ All "G" background tests: no scale needed as no stove used.
 Non-batchfed stoves (e.g., wood stoves): tests 1-15, 24, and 25 (A, B, and C reps)
 
 21A, 22A: these are batch-fed stoves. However, data is known missing. Possible that we did not use the real-time scale on these tests due to conflict with other teams- as long as weight data is available at critical time points as recorded on the transcribed testing logs, the "scale" data is OK to be missing. 
-

--- a/r_markdown/scale.Rmd
+++ b/r_markdown/scale.Rmd
@@ -79,3 +79,15 @@ Additional bad tests
 ## Summary
 
 $Scale$ data was collected during `r length(unique(scale_merged$id))` experiments between `r min(scale_merged$date, na.rm = TRUE)` and `r max(scale_merged$date, na.rm = TRUE)`. There is no $Scale$ data for tests: `r setdiff(as.character(samples$id), as.character(scale_merged$id))`.
+
+
+
+$scale$ data is expected to be missing for:
+
+All "G" background tests: no scale needed as no stove used.
+
+Non-batchfed stoves (e.g., wood stoves): tests 1-15, 24, and 25 (A, B, and C reps)
+
+
+21A, 22A: these are batch-fed stoves. However, data is known missing. Possible that we did not use the real-time scale on these tests due to conflict with other teams- as long as weight data is available at critical time points as recorded on the transcribed testing logs, the "scale" data is OK to be missing. 
+

--- a/r_markdown/scale.Rmd
+++ b/r_markdown/scale.Rmd
@@ -80,8 +80,6 @@ Additional bad tests
 
 $Scale$ data was collected during `r length(unique(scale_merged$id))` experiments between `r min(scale_merged$date, na.rm = TRUE)` and `r max(scale_merged$date, na.rm = TRUE)`. There is no $Scale$ data for tests: `r setdiff(as.character(samples$id), as.character(scale_merged$id))`.
 
-
-
 $scale$ data is expected to be missing for:
 
 All "G" background tests: no scale needed as no stove used.

--- a/r_markdown/scale.Rmd
+++ b/r_markdown/scale.Rmd
@@ -88,6 +88,5 @@ All "G" background tests: no scale needed as no stove used.
 
 Non-batchfed stoves (e.g., wood stoves): tests 1-15, 24, and 25 (A, B, and C reps)
 
-
 21A, 22A: these are batch-fed stoves. However, data is known missing. Possible that we did not use the real-time scale on these tests due to conflict with other teams- as long as weight data is available at critical time points as recorded on the transcribed testing logs, the "scale" data is OK to be missing. 
 

--- a/r_markdown/smps.Rmd
+++ b/r_markdown/smps.Rmd
@@ -203,3 +203,19 @@ Plot
 ## Data summary
 
 The $SMPS$ measured during `r length(unique(smps_merged$id))` experiments between `r min(smps_merged$date, na.rm = TRUE)` and `r max(smps_merged$date, na.rm = TRUE)`. There is no $SMPS$ data for tests: `r setdiff(as.character(samples$id), as.character(smps_merged$id))`.
+
+
+
+$SMPS$ data is expected to be missing for: 
+13A, 17A, 18A, 19A, 20A, G3, G4. "no data" was noted on QC log for these tests. 
+
+G1, 23A: test date 1/7/2016: data lost from this day. 
+29B: test date 6/29/2016; for some reason there are 2 files, part 1 and 2, where file name is 20160622_29B(1)_SMPS and 20160622_29B(2)_SMPS. Part 1 only contains 24 scans, start times from 13:14 through 14:06. Part 2 starts at 14:22, only 8 scans through 14:45 start. Test start, according to log sheet, was 13:33 - electrical problem with stove at 14:14:00 forced test shutdown early. Need to combine files, or it's possible that this whole test should be scrapped? 
+
+28A: test date 6/23/2016; file is there with correct naming convention…only 9 scans from 9:46 through 10:13; log sheet says test time was from 10:02 through 11:28…suspect an issue occurred with SMPS?
+
+11A: test date 7/19/2016; file is there with correct naming convention…42 scans from 9:53 to 12:09 - but test time in log listed as 12:12 through 13:43…suspect an issue occurred with SMPS?
+
+
+
+

--- a/r_markdown/smps.Rmd
+++ b/r_markdown/smps.Rmd
@@ -215,7 +215,3 @@ G1, 23A: test date 1/7/2016: data lost from this day.
 28A: test date 6/23/2016; file is there with correct naming convention…only 9 scans from 9:46 through 10:13; log sheet says test time was from 10:02 through 11:28…suspect an issue occurred with SMPS?
 
 11A: test date 7/19/2016; file is there with correct naming convention…42 scans from 9:53 to 12:09 - but test time in log listed as 12:12 through 13:43…suspect an issue occurred with SMPS?
-
-
-
-

--- a/r_markdown/temp.Rmd
+++ b/r_markdown/temp.Rmd
@@ -85,3 +85,10 @@ Additional bad tests
 ## Summary
 
 $Temperature$ was measured for `r length(unique(temp_merged$id))` experiments between `r min(temp_merged$date, na.rm = TRUE)` and `r max(temp_merged$date, na.rm = TRUE)`. There is no $temperature$ data for tests: `r setdiff(as.character(samples$id), as.character(temp_merged$id))`.
+
+
+$Temperature$ data is expected to be missing for: 
+All "G" tests (1-18). We did not collect stove/pot temperature for background tests as no stove was operated. 
+
+13A, 2A, and 6A (the three tests conducted on 1/5/2016), 18B, 21A (conducted on 2/10/2016), 22A (conducted on 1/13/2016), and 3A, and 7A (conducted on 2/26/2016): test data was lost. It is possible that there were some thermocouple malfunctions resulting in this data loss (check "notes" on transcribed testing sheets).  
+

--- a/r_markdown/temp.Rmd
+++ b/r_markdown/temp.Rmd
@@ -86,7 +86,6 @@ Additional bad tests
 
 $Temperature$ was measured for `r length(unique(temp_merged$id))` experiments between `r min(temp_merged$date, na.rm = TRUE)` and `r max(temp_merged$date, na.rm = TRUE)`. There is no $temperature$ data for tests: `r setdiff(as.character(samples$id), as.character(temp_merged$id))`.
 
-
 $Temperature$ data is expected to be missing for: 
 All "G" tests (1-18). We did not collect stove/pot temperature for background tests as no stove was operated. 
 

--- a/r_markdown/trans.Rmd
+++ b/r_markdown/trans.Rmd
@@ -114,3 +114,6 @@ Additional bad tests
 ## Data summary
 
 Transmissometer was was collected for `r length(unique(trans_merged$id))` experiments. There is no transmissometer data for tests: `r setdiff(as.character(samples$id), as.character(trans_merged$id))`.
+
+
+$transmissometer$ data is expected to be missing for: 17A only. This filter ruptured during the test so was not able to be transmissometer-ed. 

--- a/r_markdown/trans.Rmd
+++ b/r_markdown/trans.Rmd
@@ -115,5 +115,4 @@ Additional bad tests
 
 Transmissometer was was collected for `r length(unique(trans_merged$id))` experiments. There is no transmissometer data for tests: `r setdiff(as.character(samples$id), as.character(trans_merged$id))`.
 
-
-$transmissometer$ data is expected to be missing for: 17A only. This filter ruptured during the test so was not able to be transmissometer-ed. 
+$transmissometer$ data is expected to be missing for: 17A only. This filter ruptured during the test so was not able to be transmissometer-ed.

--- a/r_markdown/voc.Rmd
+++ b/r_markdown/voc.Rmd
@@ -136,4 +136,4 @@ Additional bad tests
 $VOCs$ were measured for `r length(unique(voc_merged$id))` experiments between `r min(voc_merged$date, na.rm = TRUE)` and `r max(voc_merged$date, na.rm = TRUE)`. There is no $VOC$ data for tests: `r setdiff(as.character(samples$id), as.character(voc_merged$id))`.
 
 
-$VOCs$ data is expected to be missing for: G18 only. We did not collect a canister for this test due to supply shortage. 
+$VOCs$ data is expected to be missing for: G18 only. We did not collect a canister for this test due to supply shortage.

--- a/r_markdown/voc.Rmd
+++ b/r_markdown/voc.Rmd
@@ -135,5 +135,4 @@ Additional bad tests
 
 $VOCs$ were measured for `r length(unique(voc_merged$id))` experiments between `r min(voc_merged$date, na.rm = TRUE)` and `r max(voc_merged$date, na.rm = TRUE)`. There is no $VOC$ data for tests: `r setdiff(as.character(samples$id), as.character(voc_merged$id))`.
 
-
 $VOCs$ data is expected to be missing for: G18 only. We did not collect a canister for this test due to supply shortage.

--- a/r_markdown/voc.Rmd
+++ b/r_markdown/voc.Rmd
@@ -134,3 +134,6 @@ Additional bad tests
 ```
 
 $VOCs$ were measured for `r length(unique(voc_merged$id))` experiments between `r min(voc_merged$date, na.rm = TRUE)` and `r max(voc_merged$date, na.rm = TRUE)`. There is no $VOC$ data for tests: `r setdiff(as.character(samples$id), as.character(voc_merged$id))`.
+
+
+$VOCs$ data is expected to be missing for: G18 only. We did not collect a canister for this test due to supply shortage. 


### PR DESCRIPTION
Added statements at the end of each QA/QC file summarizing what the expected missing data is (what tests, why), to be compared to the summary of which test IDs are missing that appears right above. Compare "expected missing" to "missing" to find out if there are problems with code that need to be resolved. 